### PR TITLE
check API and host first. add a feature to set apibase for debugging.

### DIFF
--- a/config.go
+++ b/config.go
@@ -17,8 +17,9 @@ type Trap struct {
 }
 
 type Mackerel struct {
-	ApiKey string `yaml:"x-api-key"`
-	HostID string `yaml:"host-id"`
+	ApiKey  string `yaml:"x-api-key"`
+	ApiBase string `yaml:"apibase"`
+	HostID  string `yaml:"host-id"`
 }
 
 type Charset = string

--- a/trap.go
+++ b/trap.go
@@ -72,7 +72,7 @@ func main() {
 	encodings := []Charset{CharsetShiftJis, CharsetUTF8}
 	for i := range c.Encoding {
 		if net.ParseIP(c.Encoding[i].Address) == nil {
-			log.Fatalf("cant parse ip : %q", c.Encoding[i].Address)
+			log.Fatalf("can't parse ip : %q", c.Encoding[i].Address)
 		}
 		ok := false
 		for j := range encodings {
@@ -95,7 +95,24 @@ func main() {
 		trapListener.Params.Logger = g.NewLogger(log.New(os.Stdout, "<GOSNMP DEBUG LOGGER>", 0))
 	}
 
-	client := mackerel.NewClient(c.Mackerel.ApiKey)
+	if c.Mackerel.ApiKey == "" {
+		log.Fatalf("x-api-key isn't defined.")
+	}
+	if c.Mackerel.HostID == "" {
+		log.Fatalf("host-id isn't defined.")
+	}
+
+	var client *mackerel.Client
+	if c.Mackerel.ApiBase == "" {
+		client = mackerel.NewClient(c.Mackerel.ApiKey)
+	} else {
+		client, _ = mackerel.NewClientWithOptions(c.Mackerel.ApiKey, c.Mackerel.ApiBase, false)
+	}
+
+	_, err = client.FindHost(c.Mackerel.HostID)
+	if err != nil {
+		log.Fatalf("Either x-api-key or host-id is invalid.\n%s", err)
+	}
 
 	wg := sync.WaitGroup{}
 
@@ -121,7 +138,7 @@ func main() {
 
 			case <-ctx.Done():
 				trapListener.Close()
-				log.Println("trapListener is close.")
+				log.Println("trapListener is closed.")
 				log.Println("cancellation from context:", ctx.Err())
 				return
 			}
@@ -173,7 +190,7 @@ func trapHandler(packet *g.SnmpPacket, addr *net.UDPAddr) {
 					padValue, err = transformShiftJIS(b)
 					if err != nil {
 						fmt.Printf("%+v\n", err)
-						padValue = "<can not decode>"
+						padValue = "<cannot decode>"
 					}
 				case CharsetUTF8:
 					fallthrough
@@ -210,7 +227,7 @@ func trapHandler(packet *g.SnmpPacket, addr *net.UDPAddr) {
 
 	funcmap := template.FuncMap{
 		"read": func(key string) string {
-			return fmt.Sprintf("%s", pad[key])
+			return pad[key]
 		},
 		"addr": func() string {
 			return addr.IP.String()

--- a/trap.go
+++ b/trap.go
@@ -106,7 +106,10 @@ func main() {
 	if c.Mackerel.ApiBase == "" {
 		client = mackerel.NewClient(c.Mackerel.ApiKey)
 	} else {
-		client, _ = mackerel.NewClientWithOptions(c.Mackerel.ApiKey, c.Mackerel.ApiBase, false)
+		client, err = mackerel.NewClientWithOptions(c.Mackerel.ApiKey, c.Mackerel.ApiBase, false)
+		if err != nil {
+			log.Fatalf("invalid apibase: %s", err)
+		}
 	}
 
 	_, err = client.FindHost(c.Mackerel.HostID)


### PR DESCRIPTION
変更内容単位で分けるべきだった気はしています…。必要ならバラして出し直します。

- APIとホストIDが有効かどうかをまず確認するようにしてみました。
  - 理由: 無効なまま送り続けてDoSにしたくないため。
  - ただ、この実装だと途中でホストIDが無効にされた場合に関知できません。投稿でホストIDが無効なのが複数回続いたらエラーにする、というほうがよいのかも？
  - clientの取り方は3項演算子ができないということでこういう書き方にしちゃっていますが、もっとマシな書き方があるんだろうな…という気がします。
- ローカルで試しやすいようにapibaseパラメータを取るようにしてみました。
- 英語表現と、Visual Source Codeで「このSprintfはいらないはず」というのを従ってみました。

ちょっとSNMPルータ/スイッチ持ちの人試してみてよ、というときにAPI/ホストIDなくてもとりあえずログ書き出しができるdry-run的なモードがあるといいのかも、とも少し思いました(API指定しなかったらそうするとか？)。