### PR TITLE
inspect community on packets.

### DIFF
--- a/trap.go
+++ b/trap.go
@@ -90,7 +90,6 @@ func main() {
 	trapListener := g.NewTrapListener()
 	trapListener.OnNewTrap = trapHandler
 	trapListener.Params = g.Default
-	trapListener.Params.Community = c.TrapServer.Community
 	if c.Debug {
 		trapListener.Params.Logger = g.NewLogger(log.New(os.Stdout, "<GOSNMP DEBUG LOGGER>", 0))
 	}
@@ -133,6 +132,13 @@ func main() {
 
 func trapHandler(packet *g.SnmpPacket, addr *net.UDPAddr) {
 	// log.Printf("got trapdata from %s\n", addr.IP)
+
+	if c.TrapServer.Community != packet.Community {
+		if c.Debug {
+			log.Printf("community mis match : %q %q", c.TrapServer.Community, packet.Community)
+		}
+		return
+	}
 
 	var pad = make(map[string]string)
 	var specificTrapFormat string

--- a/trap.go
+++ b/trap.go
@@ -135,7 +135,7 @@ func trapHandler(packet *g.SnmpPacket, addr *net.UDPAddr) {
 
 	if c.TrapServer.Community != packet.Community {
 		if c.Debug {
-			log.Printf("invalid community: expected '%q', but received '%q'", c.TrapServer.Community, packet.Community)
+			log.Printf("invalid community: expected %q, but received %q", c.TrapServer.Community, packet.Community)
 		}
 		return
 	}

--- a/trap.go
+++ b/trap.go
@@ -135,7 +135,7 @@ func trapHandler(packet *g.SnmpPacket, addr *net.UDPAddr) {
 
 	if c.TrapServer.Community != packet.Community {
 		if c.Debug {
-			log.Printf("community mis match : %q %q", c.TrapServer.Community, packet.Community)
+			log.Printf("invalid community: expected '%q', but received '%q'", c.TrapServer.Community, packet.Community)
 		}
 		return
 	}


### PR DESCRIPTION
trapHandlerでパケットの内容を確認して、communityが設定と異なる場合には処理をスキップするように変更します。

closes #2
