### PR TITLE
rename CheckReport.Name

### DIFF
--- a/notification/queue.go
+++ b/notification/queue.go
@@ -65,7 +65,7 @@ func (q *Queue) send(item Item) {
 		{
 			Source:     mackerel.NewCheckSourceHost(q.hostId),
 			Status:     mackerel.CheckStatusWarning,
-			Name:       fmt.Sprintf("snmptrap %s", item.Addr),
+			Name:       fmt.Sprintf("sabatrapd %s", item.Addr),
 			Message:    message,
 			OccurredAt: item.OccurredAt,
 		},


### PR DESCRIPTION
closes #16 

Name を変更しました。
アドレス単位での設定については、提案したものの、装飾よりの機能になるので、もう少し吟味したほうがいいかなと思い、このPRでは実装していません。