### PR TITLE
dry-run mode

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,14 @@ type Config struct {
 	TrapServer *TrapServer `yaml:"snmp"`
 	Trap       []*Trap     `yaml:"trap"`
 	Debug      bool        `yaml:"debug"`
+	DryRun     bool        `yaml:"dry-run"`
 	Mackerel   *Mackerel   `yaml:"mackerel"`
 	Encoding   []*Encoding `yaml:"encoding"`
+}
+
+func (c *Config) RunningMode() string {
+	if c.DryRun {
+		return "dry-run"
+	}
+	return "execute"
 }

--- a/notification/queue.go
+++ b/notification/queue.go
@@ -40,14 +40,17 @@ func (q *Queue) Enqueue(item Item) {
 }
 
 func (q *Queue) Dequeue(ctx context.Context) {
-	// log.Infof("buffers len: %d", q.q.Len())
 	if q.q.Len() == 0 {
 		return
 	}
 
 	e := q.q.Front()
-	// log.Infof("send current value: %#v", e.Value)
-	q.send(e.Value.(Item))
+	item := e.Value.(Item)
+	if q.client == nil {
+		log.Printf("receive %q %q\n", item.Addr, item.Message)
+	} else {
+		q.send(item)
+	}
 	q.m.Lock()
 	q.q.Remove(e)
 	q.m.Unlock()

--- a/trap.go
+++ b/trap.go
@@ -125,7 +125,7 @@ func main() {
 }
 
 func checkMackerelConfig(conf *config.Mackerel) (*mackerel.Client, error) {
-	if conf.ApiKey == "" {
+	if conf == nil || conf.ApiKey == "" {
 		return nil, fmt.Errorf("x-api-key isn't defined.")
 	}
 	if conf.HostID == "" {

--- a/trap.go
+++ b/trap.go
@@ -62,6 +62,14 @@ func main() {
 		}
 	}
 
+	var client *mackerel.Client
+	if !conf.DryRun {
+		client, err = checkMackerelConfig(conf.Mackerel)
+		if err != nil {
+			log.Fatalln(err)
+		}
+	}
+
 	queue := notification.NewQueue(client, conf.Mackerel.HostID)
 
 	handle := &handler.Handler{
@@ -112,7 +120,7 @@ func main() {
 			}
 		}
 	}()
-	log.Println("initialized.")
+	log.Printf("initialized. %s mode\n", conf.RunningMode())
 	wg.Wait()
 }
 


### PR DESCRIPTION
closes #15

- dry-run の実装です。
- YAML上で設定の可否が可能です。
  - 引数での指定については後続のPRで、設定ファイルの指定と共に実装します。
- mackerelのクライアント初期化ロジックを移動しました。
- dry-run で動作させる場合、mackerelのクライアントを初期化しないことで、ジョブキューでの挙動を分けています。
- どういうモードで実行されているか、起動時にメッセージを追加しています。