### PR TITLE
add arguments of dry-run, config filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-config.yaml
+sabatrapd.yml
 
 *~
 #`#

--- a/sabatrapd.yml.sample
+++ b/sabatrapd.yml.sample
@@ -1,20 +1,13 @@
 snmp:
   addr: 0.0.0.0
   port: 9162
-  community: public
 mib:
   directory:
     - "/var/lib/snmp/mibs/ietf/"
   modules:
     - SNMPv2-MIB
     - IF-MIB
-#   - CISCO-CONFIG-MAN-MIB
-#   - CISCO-GENERAL-TRAPS
-#   - CISCO-SYSLOG-MIB
-debug: false
 trap:
-# - ident: .1.3.6.1.4.1.9.9.41.2.0.1
-#   format: '[{{ addr }}] {{ read "CISCO-SYSLOG-MIB::clogHistFacility" }} is msg:{{ read "CISCO-SYSLOG-MIB::clogHistMsgName" }} text:{{ read "CISCO-SYSLOG-MIB::clogHistMsgText" }}'
   - ident: .1.3.6.1.6.3.1.1.5.1
     format: '{{ addr }} is cold started'
   - ident: .1.3.6.1.6.3.1.1.5.2

--- a/trap.go
+++ b/trap.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"log"
 	"net"
@@ -22,9 +23,18 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+var configFilename string
+var dryRun bool
+
+func init() {
+	flag.StringVar(&configFilename, "conf", "sabatrapd.yml", "config `filename`")
+	flag.BoolVar(&dryRun, "dry-run", false, "dry run mode")
+}
+
 func main() {
-	// TODO args.
-	f, err := os.ReadFile("config.yaml")
+	flag.Parse()
+
+	f, err := os.ReadFile(configFilename)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -35,6 +45,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("error: %v", err)
 	}
+	// merge dry-run argument.
+	conf.DryRun = (conf.DryRun || dryRun)
 
 	// init mib parser
 	var mibParser smi.SMI


### PR DESCRIPTION
closes #14

- 設定ファイルパスを引数で指定可能にしました。
- dry-run についても引数で指定できたほうが好都合に感じたのでこちらも追加しています。
- #21 に示されてる設定ファイル名に変更しておきました。
- 設定ファイルサンプルについても、雑多な記述を削除しておきました。
  - サンプルの内容について強いこだわりはなくREADMEの内容によってはさらに書き換えても良いと思っています。