### PR TITLE
WARNING以外のアラートを送れるようにする

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.19
+          go-version: 1.23
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: "1.19.x"
+        go-version: "1.23.x"
     - uses: actions/checkout@v3
     - uses: actions/cache@v3
       with:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ SNMP Trapとは、ネットワーク機器側からサーバーに状態の変�
 
 - 本プログラムは無保証です。
 - プロトコルはSNMP v2cのみに対応しています。
-- SNMP Trapの内容は「WARNING」としてMackerelに投稿され、アラートになります。SNMP Trapの原因が解消されてもsabatrapdでは関知できないので、Mackerel上でアラートを手動で閉じる必要があります。そのため、SNMP Trapの捕捉は最小限に留めることを推奨します。
+- SNMP Trapの内容はMackerelに投稿され、アラートになります。SNMP Trapの原因が解消されてもsabatrapdでは関知できないので、Mackerel上でアラートを手動で閉じる必要があります。そのため、SNMP Trapの捕捉は最小限に留めることを推奨します。
+  - 捕捉対象に対してあらかじめ「WARNING」「CRITICAL」「UNKNOWN」のそれぞれのステータスを設定することができます。無指定時には「WARNING」が用いられます。
 
 ## セットアップ手順（リリースアーカイブの利用）
 

--- a/config/alert.go
+++ b/config/alert.go
@@ -1,0 +1,36 @@
+package config
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+const (
+	levelUnknown  = "unknown"
+	levelCritical = "critical"
+	levelWarning  = "warning"
+)
+
+func validAlertLevel() []string {
+	return []string{levelUnknown, levelCritical, levelWarning}
+}
+
+// 無指定の場合は WARNING 入力は ValidateAlertLevel で検査されていること
+func ConvertAlertLevel(s string) mackerel.CheckStatus {
+	switch s {
+	case levelUnknown:
+		return mackerel.CheckStatusUnknown
+	case levelCritical:
+		return mackerel.CheckStatusCritical
+	}
+	return mackerel.CheckStatusWarning
+}
+
+func ValidateAlertLevel(s string) error {
+	if s != "" && !slices.Contains(validAlertLevel(), s) {
+		return fmt.Errorf("alert-level is invalid. %s, valid argument: %s", s, validAlertLevel())
+	}
+	return nil
+}

--- a/config/alert_test.go
+++ b/config/alert_test.go
@@ -1,0 +1,40 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/mackerelio/mackerel-client-go"
+)
+
+func TestValidateAlertLevel(t *testing.T) {
+	if err := ValidateAlertLevel("unknown"); err != nil {
+		t.Error(err)
+	}
+	if err := ValidateAlertLevel("critical"); err != nil {
+		t.Error(err)
+	}
+	if err := ValidateAlertLevel("warning"); err != nil {
+		t.Error(err)
+	}
+
+	err := ValidateAlertLevel("foo")
+	if err == nil {
+		t.Error("invalid result")
+	}
+
+	if err.Error() != "alert-level is invalid. foo, valid argument: [unknown critical warning]" {
+		t.Error("invalid result")
+	}
+}
+
+func TestConvertAlertLevel(t *testing.T) {
+	if ConvertAlertLevel("unknown") != mackerel.CheckStatusUnknown {
+		t.Error("invalid")
+	}
+	if ConvertAlertLevel("critical") != mackerel.CheckStatusCritical {
+		t.Error("invalid")
+	}
+	if ConvertAlertLevel("warning") != mackerel.CheckStatusWarning {
+		t.Error("invalid")
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -14,8 +14,9 @@ type TrapServer struct {
 }
 
 type Trap struct {
-	Ident  string `yaml:"ident"`
-	Format string `yaml:"format"`
+	Ident      string `yaml:"ident"`
+	Format     string `yaml:"format"`
+	AlertLevel string `yaml:"alert-level"` // warning, critical, unknown. default: warning
 }
 
 type Mackerel struct {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/yseto/sabatrapd
 
-go 1.19
+go 1.23.0
 
 require (
 	github.com/gosnmp/gosnmp v1.35.0

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -40,12 +40,14 @@ func (h *Handler) OnNewTrap(packet *g.SnmpPacket, addr *net.UDPAddr) {
 	var pad = make(map[string]string)
 	var specificTrapFormat string
 	var occurredAt = time.Now().Unix()
+	var alertLevel string
 
 	for _, v := range packet.Variables {
 		if strings.HasPrefix(v.Name, SnmpTrapOIDPrefix) {
 			for i := range config.Trap {
 				if strings.HasPrefix(v.Value.(string), config.Trap[i].Ident) {
 					specificTrapFormat = config.Trap[i].Format
+					alertLevel = config.Trap[i].AlertLevel
 				}
 			}
 		}
@@ -114,5 +116,6 @@ func (h *Handler) OnNewTrap(packet *g.SnmpPacket, addr *net.UDPAddr) {
 		OccurredAt: occurredAt,
 		Addr:       addr.IP.String(),
 		Message:    message,
+		AlertLevel: alertLevel,
 	})
 }

--- a/notification/queue_test.go
+++ b/notification/queue_test.go
@@ -87,7 +87,7 @@ func TestDryRunQueue(t *testing.T) {
 	}()
 	DryRunQueue()
 	actual := buf.String()
-	expected := `receive "192.0.2.1" "message"` + "\n"
+	expected := `receive "192.0.2.1" "message" "WARNING"` + "\n"
 	if actual != expected {
 		t.Errorf("log is invalid. get %q, want %q", actual, expected)
 	}

--- a/trap.go
+++ b/trap.go
@@ -60,9 +60,13 @@ func main() {
 	}
 	defer mibParser.Close()
 
-	// template tests.
 	for i := range conf.Trap {
+		// template tests.
 		if err := template.Parse(conf.Trap[i].Format); err != nil {
+			log.Fatalln(err)
+		}
+		// validate alert-level
+		if err := config.ValidateAlertLevel(conf.Trap[i].AlertLevel); err != nil {
 			log.Fatalln(err)
 		}
 	}


### PR DESCRIPTION
closes https://github.com/yseto/sabatrapd/issues/32

- 設定ファイルで warning, critical, unknown のいずれかを指定することで、指定したステータスのアラートが送れる
- Goの更新