### PR TITLE
メモリ消費を防ぐ

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,13 +39,14 @@ type Encoding struct {
 }
 
 type Config struct {
-	MIB        *MIB        `yaml:"mib"`
-	TrapServer *TrapServer `yaml:"snmp"`
-	Trap       []*Trap     `yaml:"trap"`
-	LogLebel   string      `yaml:"log-level"`
-	DryRun     bool        `yaml:"dry-run"`
-	Mackerel   *Mackerel   `yaml:"mackerel"`
-	Encoding   []*Encoding `yaml:"encoding"`
+	MIB          *MIB        `yaml:"mib"`
+	TrapServer   *TrapServer `yaml:"snmp"`
+	Trap         []*Trap     `yaml:"trap"`
+	LogLebel     string      `yaml:"log-level"`
+	DryRun       bool        `yaml:"dry-run"`
+	Mackerel     *Mackerel   `yaml:"mackerel"`
+	Encoding     []*Encoding `yaml:"encoding"`
+	MaxQueueSize int         `yaml:"max-queue-size"` // キューの最大サイズ
 }
 
 func (c *Config) RunningMode() string {

--- a/go.sum
+++ b/go.sum
@@ -12,6 +12,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/gosnmp/gosnmp v1.35.0 h1:EuWWNPxTCdAUx2/NbQcSa3WdNxjzpy4Phv57b4MWpJM=
 github.com/gosnmp/gosnmp v1.35.0/go.mod h1:2AvKZ3n9aEl5TJEo/fFmf/FGO4Nj4cVeEc5yuk88CYc=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
+github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/mackerelio/mackerel-client-go v0.24.0 h1:Y9FeTgrQlDdtLU7FtMM6hd5mL5T4TvGCVUY0LH+bceQ=
 github.com/mackerelio/mackerel-client-go v0.24.0/go.mod h1:b4qVMQi+w4rxtKQIFycLWXNBtIi9d0r571RzYmg/aXo=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -24,6 +25,7 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.1 h1:5TQK59W5E3v0r2duFAb7P95B6hEeOyEnHRa8MjYSMTY=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 golang.org/x/text v0.7.0 h1:4BRB4x83lYWy72KwLD/qYDuTu7q9PjSagHvijDw7cLo=
 golang.org/x/text v0.7.0/go.mod h1:mrYo+phRRbMaCq/xk9113O4dZlRixOauAjOtrjsXDZ8=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=

--- a/notification/queue_test.go
+++ b/notification/queue_test.go
@@ -115,7 +115,7 @@ func QueueClientError(t *testing.T) {
 	q.Dequeue(ctx)
 
 	actual := q.q.Len()
-	expected := 1
+	expected := 0  // エラーが発生したアイテムは破棄される
 	if actual != expected {
 		t.Errorf("queue length is invalid. want %d, get %d", expected, actual)
 	}

--- a/trap.go
+++ b/trap.go
@@ -114,6 +114,11 @@ func main() {
 	}
 
 	queue := notification.NewQueue(client, hostid)
+	
+	// 設定ファイルでキューサイズが指定されている場合は設定
+	if conf.MaxQueueSize > 0 {
+		queue.SetMaxSize(conf.MaxQueueSize)
+	}
 
 	traps, err := conf.SortedTrapRules()
 	if err != nil {


### PR DESCRIPTION
たくさんのトラップ処理設定をしているとメモリを極度に消費することがある模様。
CoPilotのアドバイスでいったんコード化してみます。

## 主な問題箇所

### 1. **queue.goの無制限キューイング**
最も深刻な問題は、`Queue`構造体のリスト（`container/list`）が無制限に成長することです：

```go
func (q *Queue) Enqueue(item Item) {
	q.m.Lock()
	q.q.PushBack(item)  // 無制限に追加される
	q.m.Unlock()
}
```

**問題点：**
- SNMPトラップを受信するたびに`Enqueue`が呼ばれる
- Mackerelへの投稿が失敗するとエラーログを出力して`return`するため、キューからアイテムが削除されない
- 投稿が失敗し続けると、キューが際限なく成長してメモリを消費

### 2. **handler.goの一時的なメモリ使用**
SNMPトラップを処理する際に、以下の箇所でメモリを使用：

```go
var pad = make(map[string]string)
var hasTrappedOIDs []string
```

**問題点：**
- 各トラップごとに新しいマップとスライスを作成
- 大量のトラップを同時に処理すると、一時的にメモリを消費

### 3. **trap.goのメインループ**
```go
t := time.NewTicker(500 * time.Millisecond)
go func() {
    for {
        select {
        case <-t.C:
            queue.Dequeue(ctx)  // 500msごとに実行
        }
    }
}()
```

**問題点：**
- キューの処理が500ms間隔で、1回につき1つのアイテムしか処理しない
- 大量のトラップが短時間で送信されると、処理が追いつかずにキューが溢れる

## 解決策の提案

1. **キューサイズの制限**
2. **バッチ処理の実装**
3. **エラー時の再試行制限**
4. **メモリ使用量の監視**

```
実装した修正内容：
 キューサイズの制限:
 
 デフォルトで1000件までの制限を設定
 制限を超えると古いアイテムを削除
 バッチ処理の実装:
 
 一度に最大10件のアイテムを処理
 処理効率を向上させてキューの蓄積を防ぐ
 エラー処理の改善:
 
 エラーが発生したアイテムは破棄（無限リトライを避ける）
 エラーログは出力するが、メモリ蓄積は防ぐ
	設定可能なキューサイズ:
	
	sabatrapd.ymlにmax-queue-size設定を追加
	運用に応じてキューサイズを調整可能
	監視機能の追加:
	
	GetQueueSize()でキューサイズを監視可能
	SetMaxSize()で動的にサイズ変更可能
	
	max-queue-size: 2000  # キューの最大サイズを2000件に設定
```